### PR TITLE
fix: repair step timeline lines and redesign bus card to Apple Maps style

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -483,6 +483,8 @@
 .detailPlaceText {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-width: 0;
 }
 
 .detailPlaceLabel {
@@ -497,6 +499,8 @@
   font-size: 14px;
   font-weight: 500;
   color: #000;
+  word-break: break-word;
+  overflow-wrap: break-word;
 
   @media (prefers-color-scheme: dark) { color: #fff; }
 }
@@ -524,7 +528,6 @@
   height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
-  margin-top: 14px;
   z-index: 1;
 
   &[data-type="walk"] { background: #aeaeb2; }
@@ -536,7 +539,7 @@
   width: 2px;
   flex: 1;
   min-height: 16px;
-  margin: 2px 0;
+  margin-top: 2px;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(
@@ -548,12 +551,13 @@
     );
   }
 
-  &[data-type="bus"] { background: rgba(0, 112, 240, 0.5); }
-  &[data-type="transfer"] { background: rgba(255, 149, 0, 0.5); }
+  &[data-type="bus"] { background: var(--color-blue); }
+  &[data-type="transfer"] { background: #ff9500; }
 }
 
 .stepBody {
   flex: 1;
+  padding-top: 14px;
   padding-bottom: 12px;
   padding-left: 8px;
   min-width: 0;
@@ -630,6 +634,57 @@
   color: var(--color-blue);
   font-weight: 600;
   margin-top: 6px;
+}
+
+/* ── Bus stop mini-timeline (Apple Maps style) ── */
+.busStops {
+  margin-top: 10px;
+}
+
+.busStopRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.busStopPin {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &[data-pin="start"] {
+    background: transparent;
+    border: 2px solid;
+  }
+}
+
+.busStopName {
+  font-size: 13px;
+  font-weight: 600;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) { color: #fff; }
+}
+
+.busStopMid {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 3px 0;
+}
+
+.busStopConnector {
+  width: 2px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.busRideLabel {
+  font-size: 13px;
+  color: var(--color-blue);
+  font-weight: 500;
 }
 
 /* ── Arrive row ── */

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -41,6 +41,7 @@ interface RouteSegment {
   fromStop?: string;
   toStop?: string;
   distanceMeters?: number;
+  stopsCount?: number;
 }
 
 interface RouteOption {
@@ -71,6 +72,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
       Math.pow((from.nearest.stop[2] - to.nearest.stop[2]) * 72000, 2)
   );
   const busDurationMin = Math.max(4, Math.ceil(stopToStopMeters / (busSpeedMps * 60)));
+  const busStopsCount = Math.max(2, Math.round(stopToStopMeters / 400));
   const walkToDep = from.nearest.walkingMinutes;
   const walkToArr = to.nearest.walkingMinutes;
 
@@ -104,6 +106,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           busDestination: "Estación",
           fromStop: from.nearest.stop[3],
           toStop: to.nearest.stop[3],
+          stopsCount: busStopsCount,
         },
         {
           type: "walk",
@@ -135,6 +138,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           busDestination: "Avenida",
           fromStop: from.nearest.stop[3],
           toStop: "Jardines de Pereda",
+          stopsCount: Math.max(2, Math.round(busStopsCount / 2)),
         },
         {
           type: "transfer",
@@ -149,6 +153,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           busDestination: "Estación",
           fromStop: "Jardines de Pereda",
           toStop: to.nearest.stop[3],
+          stopsCount: Math.max(2, Math.round(busStopsCount / 2)),
         },
         {
           type: "walk",
@@ -338,7 +343,6 @@ interface StepRowProps {
 
 function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
   const lineBg = segment.busLine ? getLineBackgroundColor(segment.busLine, "string") : "";
-  const lineFg = segment.busLine ? getLineTextColor(segment.busLine) : "";
 
   return (
     <div className={styles.step}>
@@ -386,13 +390,36 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
                   {segment.busLine}{segment.busDestination ? ` · towards ${segment.busDestination}` : ""}
                 </span>
               </div>
-              <div className={styles.stepCardSub}>
-                Board at <strong>{segment.fromStop}</strong>
+
+              <div className={styles.busStops}>
+                <div className={styles.busStopRow}>
+                  <div
+                    className={styles.busStopPin}
+                    data-pin="start"
+                    style={{ borderColor: lineBg }}
+                  />
+                  <span className={styles.busStopName}>{segment.fromStop}</span>
+                </div>
+                <div className={styles.busStopMid}>
+                  <div
+                    className={styles.busStopConnector}
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to bottom, ${lineBg} 0px, ${lineBg} 4px, transparent 4px, transparent 8px)`,
+                    }}
+                  />
+                  <span className={styles.busRideLabel}>
+                    Ride {segment.stopsCount} stop{segment.stopsCount !== 1 ? "s" : ""} · {segment.duration} min
+                  </span>
+                </div>
+                <div className={styles.busStopRow}>
+                  <div
+                    className={styles.busStopPin}
+                    data-pin="end"
+                    style={{ background: lineBg }}
+                  />
+                  <span className={styles.busStopName}>{segment.toStop}</span>
+                </div>
               </div>
-              <div className={styles.stepCardSub}>
-                Alight at <strong>{segment.toStop}</strong>
-              </div>
-              <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
         )}


### PR DESCRIPTION
- Remove margin-top from stepDot and add padding-top to stepBody so
  connecting lines flow continuously from dot to dot without gaps
- Change bus/transfer stepLine colors from semi-transparent to solid
- Add min-width/flex to detailPlaceText and word-break to detailPlaceName
  so multi-word destination addresses render fully
- Redesign bus step card with Apple Maps-style mini-timeline showing
  departure stop (hollow circle), dashed connector + "Ride N stops · X min",
  and arrival stop (filled circle)
- Add stopsCount field to RouteSegment and calculate it in buildRoutes

https://claude.ai/code/session_01Rt2mtP8tFuKa3k2Gg3zhy9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bus segments now display estimated stop count ("Ride X stop(s)") alongside duration.
  * Enhanced mini-timeline visualization for bus stop sequences.

* **Bug Fixes**
  * Improved text wrapping and layout for place names.
  * Corrected timeline spacing and visual hierarchy.

* **Style**
  * Updated bus and transfer indicator colors to solid theme values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->