### PR TITLE
Redesign trip UI: light blue cards, destination header, remove summary, fix steps

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -28,7 +28,7 @@
 
 /* ── Detail content (journey steps) ── */
 .detailContent {
-  padding: 72px var(--margin-lr) 120px;
+  padding: 80px var(--margin-lr) 120px;
 }
 
 /* ── Input field ── */
@@ -312,7 +312,7 @@
   display: block;
   width: 100%;
   text-align: left;
-  background: #f2f2f7;
+  background: rgba(0, 112, 240, 0.08);
   border-radius: 14px;
   padding: 14px 16px;
   transition: transform 0.15s;
@@ -320,7 +320,7 @@
   &:active { transform: scale(0.98); }
 
   @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
+    background: rgba(0, 112, 240, 0.15);
   }
 }
 
@@ -375,14 +375,11 @@
 .routeDuration {
   display: flex;
   align-items: center;
-  gap: 5px;
+  justify-content: center;
   background: var(--color-blue);
   color: #fff;
   border-radius: 8px;
-  padding: 5px 10px;
-  font-size: 13px;
-  font-weight: 600;
-  white-space: nowrap;
+  padding: 6px;
 }
 
 .routeChevron {
@@ -509,14 +506,16 @@
 
 .step {
   display: flex;
+  align-items: stretch;
 }
 
 .stepTimeline {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 32px;
+  width: 28px;
   flex-shrink: 0;
+  padding-top: 16px;
 }
 
 .stepDot {
@@ -524,7 +523,6 @@
   height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
-  margin-top: 14px;
   z-index: 1;
 
   &[data-type="walk"] { background: #aeaeb2; }
@@ -535,39 +533,41 @@
 .stepLine {
   width: 2px;
   flex: 1;
-  min-height: 16px;
-  margin: 2px 0;
+  min-height: 12px;
+  margin-top: 4px;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(
       to bottom,
-      #aeaeb2 0px,
-      #aeaeb2 4px,
+      #c7c7cc 0px,
+      #c7c7cc 4px,
       transparent 4px,
       transparent 8px
     );
   }
 
-  &[data-type="bus"] { background: rgba(0, 112, 240, 0.5); }
-  &[data-type="transfer"] { background: rgba(255, 149, 0, 0.5); }
+  &[data-type="bus"] { background: rgba(0, 112, 240, 0.35); }
+  &[data-type="transfer"] { background: rgba(255, 149, 0, 0.4); }
 }
 
 .stepBody {
   flex: 1;
-  padding-bottom: 12px;
-  padding-left: 8px;
+  padding-bottom: 10px;
+  padding-left: 10px;
   min-width: 0;
 }
 
 /* ── Step cards ── */
 .stepCard {
-  background: #f2f2f7;
+  background: #fff;
   border-radius: 12px;
   overflow: hidden;
   display: flex;
+  border: 1px solid rgba(0, 0, 0, 0.06);
 
   @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
+    background: #2c2c2e;
+    border-color: rgba(255, 255, 255, 0.07);
   }
 }
 
@@ -637,7 +637,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 0 0 10px;
+  padding: 4px 0 0 8px;
 }
 
 .arriveDot {
@@ -652,4 +652,5 @@
   font-size: 15px;
   font-weight: 600;
   color: #34c759;
+  padding-left: 10px;
 }

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -321,8 +321,7 @@ function RouteCard({ route, onClick }: RouteCardProps): React.JSX.Element {
         </div>
         <div className={styles.routeCardRight}>
           <div className={styles.routeDuration}>
-            <Clock size={12} aria-hidden="true" />
-            <span>{route.totalMinutes} min</span>
+            <Clock size={14} aria-hidden="true" />
           </div>
           <ChevronRight size={16} className={styles.routeChevron} aria-hidden="true" />
         </div>
@@ -519,42 +518,10 @@ function HomeTripSubview(): React.JSX.Element {
       <Fragment>
         <Nav
           isHeader={false}
-          titleText={getText("trip")}
+          titleText={toPlace?.name ?? getText("trip")}
           onBack={() => setSelectedRoute(null)}
         />
         <div className={styles.detailContent}>
-          <div className={styles.detailSummary}>
-            <div className={styles.detailSummaryRow}>
-              <div className={styles.detailTimes}>
-                <span className={styles.detailDep}>{selectedRoute.departure}</span>
-                <ArrowRight size={16} className={styles.detailSep} aria-hidden="true" />
-                <span className={styles.detailArr}>{selectedRoute.arrival}</span>
-              </div>
-              <div className={styles.detailDuration}>
-                <Clock size={13} aria-hidden="true" />
-                {selectedRoute.totalMinutes} min
-              </div>
-            </div>
-
-            <div className={styles.detailPlaces}>
-              <div className={styles.detailPlaceRow}>
-                <div className={styles.detailDot} data-type="origin" />
-                <div className={styles.detailPlaceText}>
-                  <span className={styles.detailPlaceLabel}>From</span>
-                  <span className={styles.detailPlaceName}>{fromPlace?.name}</span>
-                </div>
-              </div>
-              <div className={styles.detailPlaceConnector} />
-              <div className={styles.detailPlaceRow}>
-                <div className={styles.detailDot} data-type="destination" />
-                <div className={styles.detailPlaceText}>
-                  <span className={styles.detailPlaceLabel}>To</span>
-                  <span className={styles.detailPlaceName}>{toPlace?.name}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
           <div className={styles.stepsContainer}>
             {selectedRoute.segments.map((seg, i) => (
               <StepRow


### PR DESCRIPTION
- Route cards: swap grey background for light blue (rgba(0,112,240,0.08)) matching home menu active state
- Duration button: icon-only (no text), compact square shape
- Trip detail header: show destination name instead of generic "Trip"
- Trip detail: remove trip summary card (times + from/to section)
- Step list: white card backgrounds with subtle border, tighter timeline column (28px), align dot to card top via padding-top, cleaner connecting lines
- Arrive row: re-aligned to match new timeline column width

https://claude.ai/code/session_01AG3dYj31nXnWzWzYAYXB7Y