### PR TITLE
Fix trip timeline line color/connection and map card stop tap behavior

### DIFF
--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -102,6 +102,14 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
     });
   };
 
+  const handleMarkerClick = (stop: StopMarker): void => {
+    if (isFullscreen) {
+      openStop(stop);
+    } else {
+      setIsFullscreen(true);
+    }
+  };
+
   const renderMarkers = (showLabels: boolean = false): ReactNode =>
     stopMarkers.map((stop) => {
       const isActive = stop.id === activeStopId;
@@ -109,7 +117,7 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
         <AdvancedMarker
           key={stop.id}
           position={stop.position}
-          onClick={() => openStop(stop)}
+          onClick={() => handleMarkerClick(stop)}
           title={stop.name}
         >
           <div className="marker">

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -513,7 +513,6 @@
   align-items: center;
   width: 32px;
   flex-shrink: 0;
-  padding-bottom: 12px;
 }
 
 .stepDot {
@@ -533,7 +532,7 @@
   width: 2px;
   flex: 1;
   min-height: 20px;
-  margin: 4px 0;
+  margin: 2px 0 0 0;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -380,7 +380,13 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
           }
           data-type={segment.type}
         />
-        {!isLast && <div className={styles.stepLine} data-type={segment.type} />}
+        {!isLast && (
+          <div
+            className={styles.stepLine}
+            data-type={segment.type}
+            style={segment.type === "bus" && lineBg ? { background: lineBg } : undefined}
+          />
+        )}
       </div>
 
       <div className={styles.stepBody}>


### PR DESCRIPTION
- Timeline line now uses the actual transit line color (e.g. red for line 1)
  instead of hardcoded blue, matching the dot color already applied
- Remove padding-bottom from stepTimeline and tighten stepLine top margin
  so the connecting line visually reaches the next step's bullet dot
- Map card: tapping a stop marker in non-fullscreen mode now opens the
  fullscreen map instead of navigating to stop estimations; stop tap
  only navigates to estimations when already in fullscreen

https://claude.ai/code/session_01GWmirLrQotmVqWUJKSqw1v