### PR TITLE
Fix timeline connection to bullets and uppercase trip header

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -52,4 +52,5 @@
   margin: auto;
   padding: 4px 12px;
   box-shadow: none;
+  text-transform: uppercase;
 }

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -532,7 +532,7 @@
   width: 2px;
   flex: 1;
   min-height: 20px;
-  margin: 2px 0 0 0;
+  margin: 0;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(


### PR DESCRIPTION
- Remove gap between timeline dots and connecting line by changing .stepLine margin from '2px 0 0 0' to '0'
- Add text-transform: uppercase to .NavTitle to display trip header in uppercase format

https://claude.ai/code/session_013pbAUN9ecAAEkoUCjYfTWJ