### PR TITLE
Fix timeline bullet connection and make transfer grey

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -520,19 +520,19 @@
   height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
-  margin-top: 8px;
+  margin-top: 4px;
   z-index: 1;
 
   &[data-type="walk"] { background: #aeaeb2; }
   &[data-type="bus"] { background: var(--color-blue); }
-  &[data-type="transfer"] { background: #ff9500; }
+  &[data-type="transfer"] { background: #aeaeb2; }
 }
 
 .stepLine {
   width: 2px;
   flex: 1;
   min-height: 20px;
-  margin: 0;
+  margin-top: -4px;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(
@@ -545,7 +545,15 @@
   }
 
   &[data-type="bus"] { background: rgba(0, 112, 240, 0.5); }
-  &[data-type="transfer"] { background: rgba(255, 149, 0, 0.5); }
+  &[data-type="transfer"] {
+    background-image: repeating-linear-gradient(
+      to bottom,
+      #aeaeb2 0px,
+      #aeaeb2 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
 }
 
 .stepBody {
@@ -573,7 +581,7 @@
   align-self: stretch;
 
   &[data-type="walk"] { background: #aeaeb2; }
-  &[data-type="transfer"] { background: #ff9500; }
+  &[data-type="transfer"] { background: #aeaeb2; }
 }
 
 .stepCardContent {
@@ -593,7 +601,7 @@
 }
 
 .stepTransferIcon {
-  color: #ff9500;
+  color: #636366;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
- Reduce stepDot margin-top from 8px to 4px for better visual connection
- Add negative margin-top to stepLine to overlap with dot and create seamless connection
- Change transfer timeline elements from orange to grey to match walk sections
- Apply dashed pattern to transfer line like walk sections
- Update transfer icon color to match grey theme

https://claude.ai/code/session_01GBRXcF2xKrLV5gsB8N4SjW