### PR TITLE
Fix timeline bullet connection, show next bus line in walk steps

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -612,6 +612,7 @@
   align-items: center;
   width: 32px;
   flex-shrink: 0;
+  position: relative;
 }
 
 .stepDot {
@@ -620,6 +621,7 @@
   border-radius: 50%;
   flex-shrink: 0;
   margin-top: 4px;
+  position: relative;
   z-index: 1;
 
   &[data-type="walk"] { background: #aeaeb2; }
@@ -628,10 +630,12 @@
 }
 
 .stepLine {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   width: 2px;
-  flex: 1;
-  min-height: 20px;
-  margin-top: -6px;
+  top: 10px; /* margin-top(4) + half dot height(6) = dot center */
+  bottom: -10px; /* extend to center of next dot: 4px gap + 6px half-dot */
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(
@@ -726,6 +730,19 @@
   }
 
   @media (prefers-color-scheme: dark) { color: #aeaeb2; }
+}
+
+.stepNextBus {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  color: #636366;
+  margin-bottom: 4px;
+
+  @media (prefers-color-scheme: dark) {
+    color: #aeaeb2;
+  }
 }
 
 .stepCardTime {

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -256,10 +256,11 @@ function RouteCard({ route, onClick }: RouteCardProps): React.JSX.Element {
 
 interface StepRowProps {
   segment: RouteSegment;
+  nextSegment?: RouteSegment;
   isLast: boolean;
 }
 
-function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
+function StepRow({ segment, nextSegment, isLast }: StepRowProps): React.JSX.Element {
   const lineBg = segment.busLine ? getLineBackgroundColor(segment.busLine, "string") : "";
 
   return (
@@ -295,6 +296,21 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
                 </span>
               </div>
               <div className={styles.stepCardSub}>{segment.label}</div>
+              {nextSegment?.type === "bus" && nextSegment.busLine && (
+                <div className={styles.stepNextBus}>
+                  <Bus size={13} aria-hidden="true" />
+                  <span>Line</span>
+                  <div
+                    className={styles.pillBusLine}
+                    style={{
+                      background: getLineBackgroundColor(nextSegment.busLine, "string"),
+                      color: getLineTextColor(nextSegment.busLine),
+                    }}
+                  >
+                    {nextSegment.busLine}
+                  </div>
+                </div>
+              )}
               <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
@@ -631,6 +647,7 @@ function HomeTripSubview(): React.JSX.Element {
               <StepRow
                 key={i}
                 segment={seg}
+                nextSegment={selectedRoute.segments[i + 1]}
                 isLast={i === selectedRoute.segments.length - 1}
               />
             ))}


### PR DESCRIPTION
- Use absolute positioning on stepLine (top: 10px = dot center, bottom: -10px
  = center of next dot) so the line precisely connects dot-to-dot across steps
- Add position:relative to stepDot to enable z-index stacking over the line
- Walk steps now show a bus line pill when the next segment is a bus route

https://claude.ai/code/session_018iyFTVZdw3xDqLrQexa13C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced trip timeline visualization with improved step connectors and visual layout
  * Walking segments now display next bus information, allowing users to quickly preview their upcoming transit connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->