### PR TITLE
Filter trip routes to only show bus routes, exclude interbus and trolleybus

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -388,7 +388,7 @@ function HomeTripSubview(): React.JSX.Element {
         return;
       }
 
-      const BUS_VEHICLE_TYPES = new Set(["BUS", "INTERCITY_BUS", "TROLLEYBUS"]);
+      const BUS_VEHICLE_TYPES = new Set(["BUS"]);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const busOnlyRoutes = directionsResult.routes.filter((route: any) =>


### PR DESCRIPTION
- Updated BUS_VEHICLE_TYPES to only include 'BUS'
- Removed 'INTERCITY_BUS' (interbus) and 'TROLLEYBUS' from allowed vehicle types
- Trip planner will now only show regular bus routes

https://claude.ai/code/session_01HsUXtYDvvPpTshNew8pv43