### PR TITLE
Improve transit line display and location name formatting

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -436,7 +436,7 @@ function HomeTripSubview(): React.JSX.Element {
 
             if (step.travelMode === "TRANSIT" && step.transitDetails) {
               const transit = step.transitDetails;
-              const lineNumber = transit.transitLine?.nameShort || transit.transitLine?.name || "";
+              const lineNumber = transit.transitLine?.nameShort || "";
               const headsign = transit.headsign || "";
               const fromStop = transit.departureStop?.name || "";
               const toStop = transit.arrivalStop?.name || "";
@@ -536,7 +536,8 @@ function HomeTripSubview(): React.JSX.Element {
     const coords = await getPlaceCoordinates(pred);
     if (!coords) return null;
     const nearest = findNearestStop(coords.lat, coords.lng, Stops);
-    return { name: pred.mainText, lat: coords.lat, lng: coords.lng, nearest };
+    const longName = pred.secondaryText ? `${pred.mainText}, ${pred.secondaryText}` : pred.mainText;
+    return { name: longName, lat: coords.lat, lng: coords.lng, nearest };
   };
 
   const selectFrom = async (pred: PlacePrediction): Promise<void> => {


### PR DESCRIPTION
Staging deploy requested.

## Changes

- **Transit line display**: Removed fallback to full transit line name (`transit.transitLine?.name`) when short name is unavailable. Now only uses `nameShort` to ensure consistent, abbreviated display.

- **Location name formatting**: Enhanced place prediction names to include secondary text (e.g., city, region) when available, providing more complete location context to users. Format: `"Main Text, Secondary Text"` when secondary text exists, otherwise just `"Main Text"`.

## Test Plan

Verify transit directions display correctly with abbreviated line names and that location search results show complete addresses with city/region information.

https://claude.ai/code/session_01KRAkbEWniyesK5a4TSi1am

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined how transit lines are identified and displayed, improving accuracy of bus route labels and segment information in journey results.
  * Enhanced location display to include additional contextual information, providing clearer details about pickup and destination points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->