### PR TITLE
fix: pin firebase-tools to 15.22.3 for keep-alive fix

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -83,13 +83,8 @@ jobs:
       id-token: write
 
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.18.0
-
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@15.22.3
 
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -83,6 +83,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.18.0
+
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -102,14 +102,14 @@ jobs:
 
       - name: Deploy to Firebase Hosting (Staging)
         if: ${{ inputs.environment-name == 'Staging' }}
-        run: firebase hosting:channel:deploy --project ${{ vars.WEB_PROJECT_NAME }} ${{ inputs.channel-name }} ${{ inputs.channel-expiration }} --use-adc
+        run: firebase hosting:channel:deploy --project ${{ vars.WEB_PROJECT_NAME }} ${{ inputs.channel-name }} ${{ inputs.channel-expiration }}
 
       - name: Deploy to Firebase Hosting (Production)
         if: ${{ inputs.environment-name == 'Production' }}
-        run: firebase deploy --project ${{ vars.WEB_PROJECT_NAME }} --use-adc
+        run: firebase deploy --project ${{ vars.WEB_PROJECT_NAME }}
 
       - id: deployment_url
         name: Set environment URL
         run: |
-          URL="$(firebase --project ${{ vars.WEB_PROJECT_NAME }} --non-interactive --json hosting:channel:open ${{ inputs.channel-name }} --use-adc | jq -r '.result.url')"
+          URL="$(firebase --project ${{ vars.WEB_PROJECT_NAME }} --non-interactive --json hosting:channel:open ${{ inputs.channel-name }} | jq -r '.result.url')"
           echo "url=$URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -83,8 +83,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.18.0
+
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools@15.22.3
+        run: npm install -g firebase-tools
 
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -102,14 +102,14 @@ jobs:
 
       - name: Deploy to Firebase Hosting (Staging)
         if: ${{ inputs.environment-name == 'Staging' }}
-        run: firebase hosting:channel:deploy --project ${{ vars.WEB_PROJECT_NAME }} ${{ inputs.channel-name }} ${{ inputs.channel-expiration }}
+        run: firebase hosting:channel:deploy --project ${{ vars.WEB_PROJECT_NAME }} ${{ inputs.channel-name }} ${{ inputs.channel-expiration }} --use-adc
 
       - name: Deploy to Firebase Hosting (Production)
         if: ${{ inputs.environment-name == 'Production' }}
-        run: firebase deploy --project ${{ vars.WEB_PROJECT_NAME }}
+        run: firebase deploy --project ${{ vars.WEB_PROJECT_NAME }} --use-adc
 
       - id: deployment_url
         name: Set environment URL
         run: |
-          URL="$(firebase --project ${{ vars.WEB_PROJECT_NAME }} --non-interactive --json hosting:channel:open ${{ inputs.channel-name }} | jq -r '.result.url')"
+          URL="$(firebase --project ${{ vars.WEB_PROJECT_NAME }} --non-interactive --json hosting:channel:open ${{ inputs.channel-name }} --use-adc | jq -r '.result.url')"
           echo "url=$URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Root cause: GitHub Actions Ubuntu runners updated to Node.js 24.17.0 which introduced a keep-alive socket regression (nodejs/node#63989) breaking google-auth-library token exchange. Firebase CLI autoAuth() fails, throwing "Failed to authenticate, have you run firebase login?" despite valid WIF credentials.

firebase-tools 15.22.3 includes a fix (#10717) that disables keep-alive on the GoogleAuth transporter, working around the Node.js regression.

Fix: Pin firebase-tools to 15.22.3 in the Deploy job.

Fixes production deploys broken by the Node.js 24.17.0 keep-alive regression.