### PR TITLE
fix: use npm ecosystem in dependabot.yml (pnpm not supported)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
           - "actions/upload-artifact"
           - "actions/download-artifact"
 
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot does not support \pnpm\ as a package-ecosystem value. Fixed by changing it to \
pm\.