### PR TITLE
fix/dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
           - "actions/upload-artifact"
           - "actions/download-artifact"
 
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"

--- a/src/components/StopLines.module.css
+++ b/src/components/StopLines.module.css
@@ -42,7 +42,7 @@
   font-size: 12px;
   margin-right: 5px;
   min-width: 35px;
-  padding: 2px 0;
+  padding: 2px 8px;
   cursor: default;
 }
 
@@ -50,5 +50,5 @@
   font-size: 18px;
   margin-right: 7px;
   min-width: 48px;
-  padding: 6px 0;
+  padding: 6px 12px;
 }


### PR DESCRIPTION
## Summary

Adds horizontal padding to \StopLines\ pill buttons so long line labels (e.g. \24C2\) don't reach the pill border.

## Changes

- \src/components/StopLines.module.css\: Changed \padding: 2px 0\ → \padding: 2px 8px\ (small) and \padding: 6px 0\ → \padding: 6px 12px\ (large). Short labels like \1\ or \7C2\ stay within the existing \min-width\, so they look identical.